### PR TITLE
Change in toBoard() method bug

### DIFF
--- a/src/com/almasb/checkers/CheckersApp.java
+++ b/src/com/almasb/checkers/CheckersApp.java
@@ -74,7 +74,7 @@ public class CheckersApp extends Application {
     }
 
     private int toBoard(double pixel) {
-        return (int)(pixel + TILE_SIZE / 2) / TILE_SIZE;
+        return (int) ((pixel + TILE_SIZE) / TILE_SIZE) - 1;
     }
 
     @Override


### PR DESCRIPTION
The algorithm now returns a correct x and/or y coordinate for each piece, where it before returned different coordinates depending on which left/right top/bottom half of the game piece the user clicked.